### PR TITLE
Add Travis CI and Coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,57 +1,8 @@
+*.pyc
 MANIFEST
-
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-env/
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-*.egg-info/
-.installed.cfg
-*.egg
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
+dist/*
+cover/*
+htmlcov/*
+.tox/*
+*.egg-info
 .coverage
-.cache
-nosetests.xml
-coverage.xml
-cover/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,57 @@
-*.pyc
 MANIFEST
-dist/*
-cover/*
-htmlcov/*
-.tox/*
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: python
+
+python:
+ - pypy
+ - pypy3
+ - 2.7
+ - 3.4
+ - 3.3
+ - 3.2
+ - 2.6
+ 
+install:
+ - pip install nose
+ - pip install coverage
+ - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
+
+script:
+ - coverage run --source=inflect -m nose -x
+
+after_success:
+ - pip install coveralls
+ - coveralls
+
+after_script:
+ - coverage report
+ - pip install pep8 pyflakes
+ - pep8 --statistics --count *.py
+ - pyflakes *.py | tee >(wc -l)
+
+matrix:
+  allow_failures:
+    - python: 2.6
+    - python: 3.2
+    - python: 3.3
+    - python: 3.4
+    - python: pypy
+    - python: pypy3
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ install:
  - pip install nose
  - pip install coverage
  - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
+ # Coveralls 4.0 doesn't support Python 3.2
+ - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
 
 script:
  - coverage run --source=inflect -m nose -x

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,4 @@ after_script:
  - pyflakes *.py | tee >(wc -l)
 
 matrix:
-  allow_failures:
-    - python: 2.6
-    - python: 3.2
-    - python: 3.3
-    - python: 3.4
-    - python: pypy
-    - python: pypy3
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ python:
 sudo: false # Use container-based infrastructure
 
 install:
- - pip install coverage
- - pip install tox-travis
+ - pip install coverage tox-travis
 
 script: tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,12 @@ python:
  - 3.5
  - 3.4
  - 3.3
- - 3.2
- - 2.6
 
 sudo: false # Use container-based infrastructure
 
 install:
  - pip install nose
  - pip install coverage
- - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
- # Coveralls 4.0 doesn't support Python 3.2
- - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
 
 script:
  - coverage run --source=inflect -m nose -x

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,10 @@ python:
 sudo: false # Use container-based infrastructure
 
 install:
- - pip install nose
  - pip install coverage
+ - pip install tox-travis
 
-script:
- - coverage run --source=inflect -m nose -x
+script: tox
 
 after_success:
  - pip install coveralls
@@ -23,9 +22,6 @@ after_success:
 
 after_script:
  - coverage report
- - pip install pep8 pyflakes
- - pep8 --statistics --count *.py
- - pyflakes *.py | tee >(wc -l)
 
 matrix:
   fast_finish: true

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 ver 0.2.5
 
 * Fixed TypeError while parsing compounds (by yavarhusain)
+* Fixed encoding issue in setup.py on Python 3
 
 
 ver 0.2.4

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,10 @@
 inflect.py
 ==========
 
+.. image:: https://travis-ci.org/hugovk/inflect.py.svg?branch=travis
+    :target: https://travis-ci.org/hugovk/inflect.py
+.. image:: https://coveralls.io/repos/hugovk/inflect.py/badge.png?branch=travis :target: https://coveralls.io/r/hugovk/inflect.py?branch=travis
+
 NAME
 ====
 

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,8 @@ inflect.py
 
 .. image:: https://travis-ci.org/hugovk/inflect.py.svg?branch=travis
     :target: https://travis-ci.org/hugovk/inflect.py
-.. image:: https://coveralls.io/repos/hugovk/inflect.py/badge.png?branch=travis :target: https://coveralls.io/r/hugovk/inflect.py?branch=travis
+.. image:: https://coveralls.io/repos/hugovk/inflect.py/badge.png?branch=travis
+    :target: https://coveralls.io/r/hugovk/inflect.py?branch=travis
 
 NAME
 ====

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,10 @@
 inflect.py
 ==========
 
-.. image:: https://travis-ci.org/hugovk/inflect.py.svg?branch=travis
-    :target: https://travis-ci.org/hugovk/inflect.py
-.. image:: https://coveralls.io/repos/hugovk/inflect.py/badge.png?branch=travis
-    :target: https://coveralls.io/r/hugovk/inflect.py?branch=travis
+.. image:: https://travis-ci.org/pwdyson/inflect.py.svg?branch=travis
+    :target: https://travis-ci.org/pwdyson/inflect.py
+.. image:: https://coveralls.io/repos/pwdyson/inflect.py/badge.png?branch=travis
+    :target: https://coveralls.io/r/pwdyson/inflect.py?branch=travis
 
 NAME
 ====

--- a/inflect.py
+++ b/inflect.py
@@ -1796,7 +1796,7 @@ class engine:
         return False
 
     def _pl_check_plurals_adj(self, word1, word2):
-# VERSION: tuple in endswith requires python 2.5
+        # VERSION: tuple in endswith requires python 2.5
         word1a = word1[:word1.rfind("'")] if word1.endswith(("'s", "'")) else ''
         word2a = word2[:word2.rfind("'")] if word2.endswith(("'s", "'")) else ''
         # TODO: BUG? report upstream. I don't think you should chop off the s'
@@ -1807,8 +1807,8 @@ class engine:
         # then they return False because they are the same. Need to fix this.
 
         if word1a:
-            if word2a and (self._pl_check_plurals_N(word1a, word2a)
-                           or self._pl_check_plurals_N(word2a, word1a)):
+            if word2a and (self._pl_check_plurals_N(word1a, word2a) or
+                           self._pl_check_plurals_N(word2a, word1a)):
                 return True
         #    if word2b and ( self._pl_check_plurals_N(word1a, word2b)
         #                    or self._pl_check_plurals_N(word2b, word1a) ):

--- a/inflect.py
+++ b/inflect.py
@@ -275,7 +275,8 @@ pl_sb_C_is_ides_endings = [
     "itis",
 ]
 
-pl_sb_C_is_ides = joinstem(-2, pl_sb_C_is_ides_complete + ['.*%s' % w for w in pl_sb_C_is_ides_endings])
+pl_sb_C_is_ides = joinstem(-2, pl_sb_C_is_ides_complete + [
+    '.*%s' % w for w in pl_sb_C_is_ides_endings])
 
 pl_sb_C_is_ides_list = pl_sb_C_is_ides_complete + pl_sb_C_is_ides_endings
 
@@ -579,7 +580,8 @@ pl_sb_U_man_mans_caps_list = """
 (si_sb_U_man_mans_list, si_sb_U_man_mans_bysize,
     pl_sb_U_man_mans_bysize) = make_pl_si_lists(pl_sb_U_man_mans_list, 's', None, dojoinstem=False)
 (si_sb_U_man_mans_caps_list, si_sb_U_man_mans_caps_bysize,
-    pl_sb_U_man_mans_caps_bysize) = make_pl_si_lists(pl_sb_U_man_mans_caps_list, 's', None, dojoinstem=False)
+    pl_sb_U_man_mans_caps_bysize) = make_pl_si_lists(
+        pl_sb_U_man_mans_caps_list, 's', None, dojoinstem=False)
 
 
 pl_sb_uninflected_s_complete = [
@@ -612,7 +614,8 @@ pl_sb_uninflected_s_endings = [
     "measles",
 ]
 
-pl_sb_uninflected_s = pl_sb_uninflected_s_complete + ['.*%s' % w for w in pl_sb_uninflected_s_endings]
+pl_sb_uninflected_s = pl_sb_uninflected_s_complete + [
+    '.*%s' % w for w in pl_sb_uninflected_s_endings]
 
 pl_sb_uninflected_herd = (
     # DON'T INFLECT IN CLASSICAL MODE, OTHERWISE NORMAL INFLECTION
@@ -1830,7 +1833,8 @@ class engine:
 
         if count is not None:
             count = 1 if ((str(count) in pl_count_one) or
-                          (self.classical_dict['zero'] and str(count).lower() in pl_count_zero)) else 2
+                          (self.classical_dict['zero'] and
+                           str(count).lower() in pl_count_zero)) else 2
         else:
             count = ''
         return count
@@ -1898,7 +1902,8 @@ class engine:
                     return ' '.join(
                         lowersplit[:numword - 1] +
                         [self._plnoun(lowersplit[numword - 1], 2) +
-                            '-' + lowersplit[numword] + '-']) + ' '.join(lowersplit[(numword + 1):])
+                            '-' + lowersplit[numword] + '-']
+                        ) + ' '.join(lowersplit[(numword + 1):])
 
 # HANDLE PRONOUNS
 
@@ -1906,7 +1911,8 @@ class engine:
             if lowerword[-k:] in v:  # ends with accusivate pronoun
                 for pk, pv in pl_prep_bysize.items():
                     if lowerword[:pk] in pv:  # starts with a prep
-                        if lowerword.split() == [lowerword[:pk], lowerword[-k:]]:  # only whitespace in between
+                        if lowerword.split() == [lowerword[:pk], lowerword[-k:]]:
+                            # only whitespace in between
                             return lowerword[:-k] + pl_pron_acc[lowerword[-k:]]
 
         try:
@@ -2333,8 +2339,12 @@ class engine:
                 if lowersplit[numword] in pl_prep_list_da:
                     return ' '.join(
                         lowersplit[:numword - 1] +
-                        [(self._sinoun(lowersplit[numword - 1], 1, gender=gender) or lowersplit[numword - 1]) +
-                            '-' + lowersplit[numword] + '-']) + ' '.join(lowersplit[(numword + 1):])
+                        [(self._sinoun(lowersplit[numword - 1],
+                                       1,
+                                       gender=gender) or
+                         lowersplit[numword - 1]) +
+                            '-' + lowersplit[numword] + '-']
+                        ) + ' '.join(lowersplit[(numword + 1):])
 
 # HANDLE PRONOUNS
 
@@ -2342,7 +2352,8 @@ class engine:
             if lowerword[-k:] in v:  # ends with accusivate pronoun
                 for pk, pv in pl_prep_bysize.items():
                     if lowerword[:pk] in pv:  # starts with a prep
-                        if lowerword.split() == [lowerword[:pk], lowerword[-k:]]:  # only whitespace in between
+                        if lowerword.split() == [lowerword[:pk], lowerword[-k:]]:
+                            # only whitespace in between
                             return lowerword[:-k] + get_si_pron('acc', lowerword[-k:], gender)
 
         try:
@@ -2790,7 +2801,10 @@ class engine:
             except TypeError:
                 if '.' in str(num):
                     try:
-                        n = int(num[-1])  # numbers after decimal, so only need last one for ordinal
+                        # numbers after decimal,
+                        # so only need last one for ordinal
+                        n = int(num[-1])
+
                     except ValueError:  # ends with '.', so need to use whole string
                         n = int(num[:-1])
                 else:
@@ -2827,8 +2841,9 @@ class engine:
 
     def hundfn(self, hundreds, tens, units, mindex):
         if hundreds:
+            andword = " %s " % self.number_args['andword'] if tens or units else ''
             return "%s hundred%s%s%s, " % (unit[hundreds],  # use unit not unitfn as simpler
-                                           " %s " % self.number_args['andword'] if tens or units else '',
+                                           andword,
                                            self.tenfn(tens, units),
                                            self.millfn(mindex))
         if tens or units:
@@ -2840,7 +2855,8 @@ class engine:
         if units == 1:
             return " %s, " % self.number_args['one']
         elif units:
-            # TODO: bug one and zero are padded with a space but other numbers aren't. check this in perl
+            # TODO: bug one and zero are padded with a space but other numbers
+            # aren't. check this in perl
             return "%s, " % unit[units]
         else:
             return " %s, " % self.number_args['zero']
@@ -2848,7 +2864,8 @@ class engine:
     def group1bsub(self, mo):
         units = int(mo.group(1))
         if units:
-            # TODO: bug one and zero are padded with a space but other numbers aren't. check this in perl
+            # TODO: bug one and zero are padded with a space but other numbers
+            # aren't. check this in perl
             return "%s, " % unit[units]
         else:
             return " %s, " % self.number_args['zero']
@@ -2870,7 +2887,8 @@ class engine:
             hunword = " %s" % self.number_args['one']
         elif hundreds:
             hunword = "%s" % unit[hundreds]
-            # TODO: bug one and zero are padded with a space but other numbers aren't. check this in perl
+            # TODO: bug one and zero are padded with a space but other numbers
+            # aren't. check this in perl
         else:
             hunword = " %s" % self.number_args['zero']
         if tens:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[flake8]
+max-line-length = 99

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import inflect
 
 here = os.path.dirname(__file__)
 readme_path = os.path.join(here, 'README.rst')
-readme = open(readme_path).read()
+readme = open(readme_path, 'rb').read().decode('utf-8')
 
 setup(
     name='inflect',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ readme = open(readme_path, 'rb').read().decode('utf-8')
 setup(
     name='inflect',
     version=inflect.__version__,
-    description='Correctly generate plurals, singular nouns, ordinals, indefinite articles; convert numbers to words',
+    description='Correctly generate plurals, singular nouns, ordinals, '
+                'indefinite articles; convert numbers to words',
     long_description=readme,
     author='Paul Dyson',
     author_email='pwdyson@yahoo.com',

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,8 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/test_classical_all.py
+++ b/tests/test_classical_all.py
@@ -9,42 +9,66 @@ class test(unittest.TestCase):
 
         # DEFAULT...
 
-        self.assertEqual(p.plural_noun('error', 0),   'errors',      msg="classical 'zero' not active")
-        self.assertEqual(p.plural_noun('wildebeest'), 'wildebeests', msg="classical 'herd' not active")
-        self.assertEqual(p.plural_noun('Sally'),      'Sallys',      msg="classical 'names' active")
-        self.assertEqual(p.plural_noun('brother'),    'brothers',    msg="classical others not active")
-        self.assertEqual(p.plural_noun('person'),     'people',      msg="classical 'persons' not active")
-        self.assertEqual(p.plural_noun('formula'),    'formulas',    msg="classical 'ancient' not active")
+        self.assertEqual(p.plural_noun('error', 0), 'errors',
+                         msg="classical 'zero' not active")
+        self.assertEqual(p.plural_noun('wildebeest'), 'wildebeests',
+                         msg="classical 'herd' not active")
+        self.assertEqual(p.plural_noun('Sally'), 'Sallys',
+                         msg="classical 'names' active")
+        self.assertEqual(p.plural_noun('brother'), 'brothers',
+                         msg="classical others not active")
+        self.assertEqual(p.plural_noun('person'), 'people',
+                         msg="classical 'persons' not active")
+        self.assertEqual(p.plural_noun('formula'), 'formulas',
+                         msg="classical 'ancient' not active")
 
         # CLASSICAL PLURALS ACTIVATED...
 
         p.classical(all=True)
-        self.assertEqual(p.plural_noun('error', 0),   'error',       msg="classical 'zero' active")
-        self.assertEqual(p.plural_noun('wildebeest'), 'wildebeest',  msg="classical 'herd' active")
-        self.assertEqual(p.plural_noun('Sally'),      'Sallys',      msg="classical 'names' active")
-        self.assertEqual(p.plural_noun('brother'),    'brethren',    msg="classical others active")
-        self.assertEqual(p.plural_noun('person'),     'persons',     msg="classical 'persons' active")
-        self.assertEqual(p.plural_noun('formula'),    'formulae',    msg="classical 'ancient' active")
+        self.assertEqual(p.plural_noun('error', 0), 'error',
+                         msg="classical 'zero' active")
+        self.assertEqual(p.plural_noun('wildebeest'), 'wildebeest',
+                         msg="classical 'herd' active")
+        self.assertEqual(p.plural_noun('Sally'), 'Sallys',
+                         msg="classical 'names' active")
+        self.assertEqual(p.plural_noun('brother'), 'brethren',
+                         msg="classical others active")
+        self.assertEqual(p.plural_noun('person'), 'persons',
+                         msg="classical 'persons' active")
+        self.assertEqual(p.plural_noun('formula'), 'formulae',
+                         msg="classical 'ancient' active")
 
         # CLASSICAL PLURALS DEACTIVATED...
 
         p.classical(all=False)
-        self.assertEqual(p.plural_noun('error', 0),   'errors',      msg="classical 'zero' not active")
-        self.assertEqual(p.plural_noun('wildebeest'), 'wildebeests', msg="classical 'herd' not active")
-        self.assertEqual(p.plural_noun('Sally'),      'Sallies',     msg="classical 'names' not active")
-        self.assertEqual(p.plural_noun('brother'),    'brothers',    msg="classical others not active")
-        self.assertEqual(p.plural_noun('person'),     'people',      msg="classical 'persons' not active")
-        self.assertEqual(p.plural_noun('formula'),    'formulas',    msg="classical 'ancient' not active")
+        self.assertEqual(p.plural_noun('error', 0), 'errors',
+                         msg="classical 'zero' not active")
+        self.assertEqual(p.plural_noun('wildebeest'), 'wildebeests',
+                         msg="classical 'herd' not active")
+        self.assertEqual(p.plural_noun('Sally'), 'Sallies',
+                         msg="classical 'names' not active")
+        self.assertEqual(p.plural_noun('brother'), 'brothers',
+                         msg="classical others not active")
+        self.assertEqual(p.plural_noun('person'), 'people',
+                         msg="classical 'persons' not active")
+        self.assertEqual(p.plural_noun('formula'), 'formulas',
+                         msg="classical 'ancient' not active")
 
         # CLASSICAL PLURALS REREREACTIVATED...
 
         p.classical()
-        self.assertEqual(p.plural_noun('error', 0),   'error',       msg="classical 'zero' active")
-        self.assertEqual(p.plural_noun('wildebeest'), 'wildebeest',  msg="classical 'herd' active")
-        self.assertEqual(p.plural_noun('Sally'),      'Sallys',      msg="classical 'names' active")
-        self.assertEqual(p.plural_noun('brother'),    'brethren',    msg="classical others active")
-        self.assertEqual(p.plural_noun('person'),     'persons',     msg="classical 'persons' active")
-        self.assertEqual(p.plural_noun('formula'),    'formulae',    msg="classical 'ancient' active")
+        self.assertEqual(p.plural_noun('error', 0), 'error',
+                         msg="classical 'zero' active")
+        self.assertEqual(p.plural_noun('wildebeest'), 'wildebeest',
+                         msg="classical 'herd' active")
+        self.assertEqual(p.plural_noun('Sally'), 'Sallys',
+                         msg="classical 'names' active")
+        self.assertEqual(p.plural_noun('brother'), 'brethren',
+                         msg="classical others active")
+        self.assertEqual(p.plural_noun('person'), 'persons',
+                         msg="classical 'persons' active")
+        self.assertEqual(p.plural_noun('formula'), 'formulae',
+                         msg="classical 'ancient' active")
 
 if __name__ == '__main__':
     try:

--- a/tests/test_inflections.py
+++ b/tests/test_inflections.py
@@ -72,9 +72,17 @@ def check_all(p, is_nv, singular, mod_PL_val, class_PL_val, mod_plural, class_pl
     eq_(mod_plural, mod_PL_val)
     eq_(class_plural, class_PL_val)
     eq_(is_eq(p, singular, mod_plural) in ('s:p', 'p:s', 'eq'), True,
-        msg='is_eq(%s,%s) == %s != %s' % (singular, mod_plural, is_eq(p, singular, mod_plural), 's:p, p:s or eq'))
+        msg='is_eq(%s,%s) == %s != %s' % (
+            singular,
+            mod_plural,
+            is_eq(p, singular, mod_plural),
+            's:p, p:s or eq'))
     eq_(is_eq(p, mod_plural, singular) in ('p:s', 's:p', 'eq'), True,
-        msg='is_eq(%s,%s) == %s != %s' % (mod_plural, singular, is_eq(p, mod_plural, singular), 's:p, p:s or eq'))
+        msg='is_eq(%s,%s) == %s != %s' % (
+            mod_plural,
+            singular,
+            is_eq(p, mod_plural, singular),
+            's:p, p:s or eq'))
     eq_(is_eq(p, singular, class_plural) in ('s:p', 'p:s', 'eq'), True)
     eq_(is_eq(p, class_plural, singular) in ('p:s', 's:p', 'eq'), True)
     assert_not_equal(singular, '')
@@ -82,10 +90,12 @@ def check_all(p, is_nv, singular, mod_PL_val, class_PL_val, mod_plural, class_pl
 
     if is_nv != '_V':
         eq_(p.singular_noun(mod_plural, 1), singular,
-            msg="p.singular_noun(%s) == %s != %s" % (mod_plural, p.singular_noun(mod_plural, 1), singular))
+            msg="p.singular_noun(%s) == %s != %s" % (
+                mod_plural, p.singular_noun(mod_plural, 1), singular))
 
         eq_(p.singular_noun(class_plural, 1), singular,
-            msg="p.singular_noun(%s) == %s != %s" % (class_plural, p.singular_noun(class_plural, 1), singular))
+            msg="p.singular_noun(%s) == %s != %s" % (
+                class_plural, p.singular_noun(class_plural, 1), singular))
 
     '''
     don't see any test data for this ???
@@ -552,10 +562,12 @@ def get_data():
                 helix  ->  helices
             hepatitis  ->  hepatitises|hepatitides
     TODO:singular_noun 2 values              her  ->  them                           # PRONOUN
-    TODO:singular_noun 2 values              her  ->  their                          # POSSESSIVE ADJ
+    TODO:singular_noun 2 values              her  ->  their
+         # POSSESSIVE ADJ
                  hero  ->  heroes
                herpes  ->  herpes
-    TODO:singular_noun 2 values             hers  ->  theirs                         # POSSESSIVE NOUN
+    TODO:singular_noun 2 values             hers  ->  theirs
+         # POSSESSIVE NOUN
     TODO:singular_noun 2 values          herself  ->  themselves
                hetman  ->  hetmans
                hiatus  ->  hiatuses|hiatus
@@ -565,8 +577,10 @@ def get_data():
     TODO:singular_noun 2 values          himself  ->  themselves
          hippopotamus  ->  hippopotamuses|hippopotami
            Hiroshiman  ->  Hiroshimans
-    TODO:singular_noun 2 values              his  ->  their                          # POSSESSIVE ADJ
-    TODO:singular_noun 2 values              his  ->  theirs                         # POSSESSIVE NOUN
+    TODO:singular_noun 2 values              his  ->  their
+         # POSSESSIVE ADJ
+    TODO:singular_noun 2 values              his  ->  theirs
+         # POSSESSIVE NOUN
     TODO:siverb             hoes  ->  hoe
            honorarium  ->  honorariums|honoraria
                  hoof  ->  hoofs|hooves
@@ -930,9 +944,12 @@ def get_data():
                testes  ->  testes
       TODO:singular_noun multiple return         testis  ->  testes
       TODO:siadj           that  ->  those
-      TODO:siadj          their  ->  their                          # POSSESSIVE FORM (GENDER-INCLUSIVE)
-      TODO:singular_noun multiple return       themself  ->  themselves                     # ugly but gaining currency
-      TODO:singular_noun multiple return           they  ->  they                           # for indeterminate gender
+      TODO:siadj          their  ->  their
+           # POSSESSIVE FORM (GENDER-INCLUSIVE)
+      TODO:singular_noun multiple return       themself  ->  themselves
+           # ugly but gaining currency
+      TODO:singular_noun multiple return           they  ->  they
+           # for indeterminate gender
                 thief  ->  thiefs|thieves
       TODO:siadj           this  ->  these
               thought  ->  thoughts                       # NOUN FORM
@@ -953,8 +970,10 @@ def get_data():
             to itself  ->  to themselves
                 to me  ->  to us
             to myself  ->  to ourselves
-      TODO:singular_noun multivalue        to them  ->  to them                        # for indeterminate gender
-      TODO:singular_noun multivalue    to themself  ->  to themselves                  # ugly but gaining currency
+      TODO:singular_noun multivalue        to them  ->  to them
+           # for indeterminate gender
+      TODO:singular_noun multivalue    to themself  ->  to themselves
+            # ugly but gaining currency
                to you  ->  to you
           to yourself  ->  to yourselves
             Tocharese  ->  Tocharese

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -24,8 +24,10 @@ def test_join():
         (p.join(words, final_sep='...', conj=''), "apple, banana... carrot"))
 
     eq_(p.join(words, conj='or'),
-        "apple, banana, or carrot", msg='%s != %s    3 words, different conjunction' % (p.join(words, conj='or'),
-        "apple, banana, or carrot"))
+        "apple, banana, or carrot",
+        msg='%s != %s    3 words, different conjunction' % (
+            p.join(words, conj='or'),
+            "apple, banana, or carrot"))
 
     # Three words with semicolons...
     words = ('apple,fuji', 'banana', 'carrot')

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -20,8 +20,9 @@ def test_join():
         "apple, banana... and carrot", msg='3 words, different final sep')
 
     eq_(p.join(words, final_sep='...', conj=''),
-        "apple, banana... carrot", msg='-->%s != %s<--   3 words, different final sep, no conjunction' %
-        (p.join(words, final_sep='...', conj=''), "apple, banana... carrot"))
+        "apple, banana... carrot",
+        msg='-->%s != %s<--   3 words, different final sep, no conjunction' % (
+        p.join(words, final_sep='...', conj=''), "apple, banana... carrot"))
 
     eq_(p.join(words, conj='or'),
         "apple, banana, or carrot",
@@ -34,17 +35,22 @@ def test_join():
 
     eq_(p.join(words),
         "apple,fuji; banana; and carrot",
-        msg='%s != %s<-- comma-inclusive 3 words' % (p.join(words), "apple,fuji, banana; and carrot"))
+        msg='%s != %s<-- comma-inclusive 3 words' % (
+            p.join(words), "apple,fuji, banana; and carrot"))
 
     eq_(p.join(words, final_sep=''),
-        "apple,fuji; banana and carrot", msg='join(%s) == "%s" != "%s"' % (words, p.join(words, final_sep=''),
-                                                                           "apple,fuji) banana and carrot"))
+        "apple,fuji; banana and carrot",
+        msg='join(%s) == "%s" != "%s"' % (
+            words,
+            p.join(words, final_sep=''),
+            "apple,fuji) banana and carrot"))
 
     eq_(p.join(words, final_sep='...'),
         "apple,fuji; banana... and carrot", msg='comma-inclusive 3 words, different final sep')
 
     eq_(p.join(words, final_sep='...', conj=''),
-        "apple,fuji; banana... carrot", msg='comma-inclusive 3 words, different final sep, no conjunction')
+        "apple,fuji; banana... carrot",
+        msg='comma-inclusive 3 words, different final sep, no conjunction')
 
     eq_(p.join(words, conj='or'),
         "apple,fuji; banana; or carrot", msg='comma-inclusive 3 words, different conjunction')

--- a/tests/test_numwords.py
+++ b/tests/test_numwords.py
@@ -44,8 +44,10 @@ def test_lines():
     eq_(p.number_to_words(999.3, threshold=500, comma=0), '999.3', msg=' 999.3 -> 999.3')
     eq_(p.number_to_words(1000.3, threshold=500, comma=0), '1000.3', msg='1000.3 -> 1000.3')
     eq_(p.number_to_words(10000.3, threshold=500, comma=0), '10000.3', msg='10000.3 -> 10000.3')
-    eq_(p.number_to_words(100000.3, threshold=500, comma=0), '100000.3', msg='100000.3 -> 100000.3')
-    eq_(p.number_to_words(1000000.3, threshold=500, comma=0), '1000000.3', msg='1000000.3 -> 1000000.3')
+    eq_(p.number_to_words(100000.3, threshold=500, comma=0), '100000.3',
+        msg='100000.3 -> 100000.3')
+    eq_(p.number_to_words(1000000.3, threshold=500, comma=0), '1000000.3',
+        msg='1000000.3 -> 1000000.3')
 
 
 def test_array():
@@ -318,65 +320,93 @@ def test_array():
             "one hundred thousand and first",
         ], [
             "123456",
-            "one hundred and twenty-three thousand, four hundred and fifty-six",
+            "one hundred and twenty-three thousand, "
+            "four hundred and fifty-six",
             "one, two, three, four, five, six",
             "twelve, thirty-four, fifty-six",
             "one twenty-three, four fifty-six",
-            "one hundred and twenty-three thousand, four hundred and fifty-sixth",
+            "one hundred and twenty-three thousand, "
+            "four hundred and fifty-sixth",
         ], [
             "0123456",
-            "one hundred and twenty-three thousand, four hundred and fifty-six",
+            "one hundred and twenty-three thousand, "
+            "four hundred and fifty-six",
             "zero, one, two, three, four, five, six",
             "zero one, twenty-three, forty-five, six",
             "zero twelve, three forty-five, six",
-            "one hundred and twenty-three thousand, four hundred and fifty-sixth",
+            "one hundred and twenty-three thousand, "
+            "four hundred and fifty-sixth",
         ], [
             "1234567",
-            "one million, two hundred and thirty-four thousand, five hundred and sixty-seven",
+            "one million, two hundred and thirty-four thousand, "
+            "five hundred and sixty-seven",
             "one, two, three, four, five, six, seven",
             "twelve, thirty-four, fifty-six, seven",
             "one twenty-three, four fifty-six, seven",
-            "one million, two hundred and thirty-four thousand, five hundred and sixty-seventh",
+            "one million, two hundred and thirty-four thousand, "
+            "five hundred and sixty-seventh",
         ], [
             "12345678",
-            "twelve million, three hundred and forty-five thousand, six hundred and seventy-eight",
+            "twelve million, three hundred and forty-five thousand, "
+            "six hundred and seventy-eight",
             "one, two, three, four, five, six, seven, eight",
             "twelve, thirty-four, fifty-six, seventy-eight",
             "one twenty-three, four fifty-six, seventy-eight",
-            "twelve million, three hundred and forty-five thousand, six hundred and seventy-eighth",
+            "twelve million, three hundred and forty-five thousand, "
+            "six hundred and seventy-eighth",
         ], [
             "12_345_678",
-            "twelve million, three hundred and forty-five thousand, six hundred and seventy-eight",
+            "twelve million, three hundred and forty-five thousand, "
+            "six hundred and seventy-eight",
             "one, two, three, four, five, six, seven, eight",
             "twelve, thirty-four, fifty-six, seventy-eight",
             "one twenty-three, four fifty-six, seventy-eight",
         ], [
             "1234,5678",
-            "twelve million, three hundred and forty-five thousand, six hundred and seventy-eight",
+            "twelve million, three hundred and forty-five thousand, "
+            "six hundred and seventy-eight",
             "one, two, three, four, five, six, seven, eight",
             "twelve, thirty-four, fifty-six, seventy-eight",
             "one twenty-three, four fifty-six, seventy-eight",
         ], [
             "1234567890",
-            "one billion, two hundred and thirty-four million, five hundred and sixty-seven thousand, eight hundred and ninety",
+            "one billion, two hundred and thirty-four million, five hundred "
+            "and sixty-seven thousand, eight hundred and ninety",
             "one, two, three, four, five, six, seven, eight, nine, zero",
             "twelve, thirty-four, fifty-six, seventy-eight, ninety",
             "one twenty-three, four fifty-six, seven eighty-nine, zero",
-            "one billion, two hundred and thirty-four million, five hundred and sixty-seven thousand, eight hundred and ninetieth",
+            "one billion, two hundred and thirty-four million, five hundred "
+            "and sixty-seven thousand, eight hundred and ninetieth",
         ], [
             "123456789012345",
-            "one hundred and twenty-three trillion, four hundred and fifty-six billion, seven hundred and eighty-nine million, twelve thousand, three hundred and forty-five",
-            "one, two, three, four, five, six, seven, eight, nine, zero, one, two, three, four, five",
-            "twelve, thirty-four, fifty-six, seventy-eight, ninety, twelve, thirty-four, five",
-            "one twenty-three, four fifty-six, seven eighty-nine, zero twelve, three forty-five",
-            "one hundred and twenty-three trillion, four hundred and fifty-six billion, seven hundred and eighty-nine million, twelve thousand, three hundred and forty-fifth",
+            "one hundred and twenty-three trillion, four hundred and "
+            "fifty-six billion, seven hundred and eighty-nine million, twelve "
+            "thousand, three hundred and forty-five",
+            "one, two, three, four, five, six, seven, eight, nine, zero, one, "
+            "two, three, four, five",
+            "twelve, thirty-four, fifty-six, seventy-eight, ninety, twelve, "
+            "thirty-four, five",
+            "one twenty-three, four fifty-six, seven eighty-nine, "
+            "zero twelve, three forty-five",
+            "one hundred and twenty-three trillion, four hundred and "
+            "fifty-six billion, seven hundred and eighty-nine million, "
+            "twelve thousand, three hundred and forty-fifth",
         ], [
             "12345678901234567890",
-            "twelve quintillion, three hundred and forty-five quadrillion, six hundred and seventy-eight trillion, nine hundred and one billion, two hundred and thirty-four million, five hundred and sixty-seven thousand, eight hundred and ninety",
-            "one, two, three, four, five, six, seven, eight, nine, zero, one, two, three, four, five, six, seven, eight, nine, zero",
-            "twelve, thirty-four, fifty-six, seventy-eight, ninety, twelve, thirty-four, fifty-six, seventy-eight, ninety",
-            "one twenty-three, four fifty-six, seven eighty-nine, zero twelve, three forty-five, six seventy-eight, ninety",
-            "twelve quintillion, three hundred and forty-five quadrillion, six hundred and seventy-eight trillion, nine hundred and one billion, two hundred and thirty-four million, five hundred and sixty-seven thousand, eight hundred and ninetieth",
+            "twelve quintillion, three hundred and forty-five quadrillion, "
+            "six hundred and seventy-eight trillion, nine hundred and one "
+            "billion, two hundred and thirty-four million, five hundred and "
+            "sixty-seven thousand, eight hundred and ninety",
+            "one, two, three, four, five, six, seven, eight, nine, zero, one, "
+            "two, three, four, five, six, seven, eight, nine, zero",
+            "twelve, thirty-four, fifty-six, seventy-eight, ninety, twelve, "
+            "thirty-four, fifty-six, seventy-eight, ninety",
+            "one twenty-three, four fifty-six, seven eighty-nine, "
+            "zero twelve, three forty-five, six seventy-eight, ninety",
+            "twelve quintillion, three hundred and forty-five quadrillion, "
+            "six hundred and seventy-eight trillion, nine hundred and one "
+            "billion, two hundred and thirty-four million, five hundred and "
+            "sixty-seven thousand, eight hundred and ninetieth",
         ], [
             "0.987654",
             "zero point nine eight seven six five four",
@@ -463,7 +493,8 @@ def go(p, i):
         eq_(p.number_to_words(i[0], group=2), i[3])
         eq_(p.number_to_words(i[0], group=3), i[4])
         if len(i) > 5:
-            eq_(p.number_to_words(p.ordinal(i[0])), i[5], msg="number_to_words(ordinal(%s)) == %s != %s" % (
+            eq_(p.number_to_words(p.ordinal(i[0])), i[5],
+                msg="number_to_words(ordinal(%s)) == %s != %s" % (
                 i[0], p.number_to_words(p.ordinal(i[0])),
                 i[5]))
         if len(i) > 6:

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -255,6 +255,7 @@ class test(unittest.TestCase):
             (p.plural_noun, '', ''),
             (p.plural_noun, 'cow', 'cows'),
             (p.plural_noun, 'thought', 'thoughts'),
+            (p.plural_noun, 'snooze', 'snoozes'),
             (p.plural_verb, '', ''),
             (p.plural_verb, 'runs', 'run'),
             (p.plural_verb, 'thought', 'thought'),
@@ -303,6 +304,23 @@ class test(unittest.TestCase):
         ):
             self.assertEqual(p.singular_noun(plur), sing)
             self.assertEqual(p.inflect('singular_noun(%s)' % plur), sing)
+
+        self.assertEqual(p.singular_noun('cats', count=2), 'cats')
+
+        self.assertEqual(p.singular_noun('zombies'), 'zombie')
+
+        self.assertEqual(p.singular_noun('shoes'), 'shoe')
+
+        self.assertEqual(p.singular_noun('Matisses'), 'Matisse')
+        self.assertEqual(p.singular_noun('bouillabaisses'), 'bouillabaisse')
+
+        self.assertEqual(p.singular_noun('quartzes'), 'quartz')
+
+        self.assertEqual(p.singular_noun('Nietzsches'), 'Nietzsche')
+        self.assertEqual(p.singular_noun('aches'), 'ache')
+
+        self.assertEqual(p.singular_noun('Clives'), 'Clive')
+        self.assertEqual(p.singular_noun('weaves'), 'weave')
 
     def test_gender(self):
         p = inflect.engine()
@@ -365,6 +383,9 @@ class test(unittest.TestCase):
             ('he or she', 'they', 'masculine or feminine'),
         ):
             self.assertEqual(p.singular_noun(plur, gender=gen), sing)
+
+        with self.assertRaises(BadGenderError):
+            p.singular_noun('cats', gender='unknown gender')
 
     def test_plequal(self):
         p = inflect.engine()
@@ -724,6 +745,7 @@ class test(unittest.TestCase):
         self.assertEqual(p.a('cat', 2), '2 cat')
 
         self.assertEqual(p.a, p.an)
+        self.assertEqual(p.a(''), '')
 
     def test_no(self):
         p = inflect.engine()
@@ -1107,6 +1129,11 @@ class test(unittest.TestCase):
                      'wordlist',
                      ):
             self.assertRaises(DeprecationWarning, getattr, p, meth)
+
+    def test_unknown_method(self):
+        p = inflect.engine()
+        with self.assertRaises(AttributeError):
+            p.unknown_method
 
 
 # TODO: test .inflectrc file code

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -9,7 +9,8 @@ import inflect
 
 class test(unittest.TestCase):
     def TODO(self, ans, answer_wanted,
-             answer_gives_now="default_that_will_never_occur__can't_use_None_as_that_is_a_possible_valid_value"):
+             answer_gives_now="default_that_will_never_occur__can't_use_None"
+                              "_as_that_is_a_possible_valid_value"):
         '''
         make this test for future testing
 
@@ -17,7 +18,8 @@ class test(unittest.TestCase):
         '''
         if ans == answer_wanted:
             print('test unexpectedly passed!: %s == %s' % (ans, answer_wanted))
-        if answer_gives_now != "default_that_will_never_occur__can't_use_None_as_that_is_a_possible_valid_value":
+        if answer_gives_now != ("default_that_will_never_occur__can't_use_None"
+                                "_as_that_is_a_possible_valid_value"):
             self.assertEqual(ans, answer_gives_now)
 
     def test_enclose(self):
@@ -646,7 +648,8 @@ class test(unittest.TestCase):
         self.assertEqual(p._pl_special_verb('canoes'), 'canoe')
         self.assertEqual(p._pl_special_verb('horseshoes'), 'horseshoe')
         self.assertEqual(p._pl_special_verb('does'), 'do')
-        self.assertEqual(p._pl_special_verb('zzzoes'), 'zzzo')  # TODO: what's a real word to test this case?
+        # TODO: what's a real word to test this case?
+        self.assertEqual(p._pl_special_verb('zzzoes'), 'zzzo')
         self.assertEqual(p._pl_special_verb('runs'), 'run')
 
     def test__pl_general_verb(self):
@@ -873,7 +876,8 @@ class test(unittest.TestCase):
         self.assertEqual(enword('123456', -1),
                          'one hundred and twenty-three  thousand, four hundred and fifty-six  , ')
         self.assertEqual(enword('1234567', -1),
-                         'one million, two hundred and thirty-four  thousand, five hundred and sixty-seven  , ')
+                         'one million, two hundred and thirty-four  thousand, '
+                         'five hundred and sixty-seven  , ')
 
     def test_numwords(self):
         p = inflect.engine()
@@ -947,7 +951,8 @@ class test(unittest.TestCase):
         self.assertEqual(numwords('1', decimal=None),
                          'one')
         self.assertEqual(numwords('1234.5678', decimal=None),
-                         'twelve million, three hundred and forty-five thousand, six hundred and seventy-eight')
+                         'twelve million, three hundred and forty-five '
+                         'thousand, six hundred and seventy-eight')
 
     def test_numwords_group(self):
         p = inflect.engine()
@@ -1053,7 +1058,8 @@ class test(unittest.TestCase):
             self.assertEqual("There %s%s" % (p.plural_verb('was', errors), p.no(" error", errors)),
                              txt)
 
-            self.assertEqual(p.inflect("There plural_verb(was,%d) no(error,%d)" % (errors, errors)),
+            self.assertEqual(p.inflect(
+                "There plural_verb(was,%d) no(error,%d)" % (errors, errors)),
                              txt)
 
         for num1, num2, txt in (

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,4 @@ deps =
 commands =
     pep8 --statistics --count .
     pyflakes . | tee >(wc -l)
+skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,py35
+envlist = py27,py33,py34,py35
 
 [testenv]
 deps=nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,24 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27, py33, py34, py35
+
+[tox:travis]
+pypy = pypy
+pypy3 = pypy3
+2.7 = py27
+3.3 = py33
+3.4 = py34
+3.5 = py35, flake8
 
 [testenv]
-deps=nose
-commands=nosetests []
+deps =
+    coverage
+    nose
+commands = coverage run --source=inflect -m nose -x
+
+[testenv:flake8]
+deps =
+    pep8
+    pyflakes
+commands =
+    pep8 --statistics --count .
+    pyflakes . | tee >(wc -l)

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,6 @@ deps =
     pep8
     pyflakes
 commands =
-    pyflakes .
+    pyflakes inflect.py setup.py tests
     pep8 --statistics --count .
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,6 @@ deps =
     pep8
     pyflakes
 commands =
+    pyflakes .
     pep8 --statistics --count .
-    pyflakes . | tee >(wc -l)
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -16,10 +16,7 @@ deps =
 commands = coverage run --source=inflect -m nose -x
 
 [testenv:flake8]
-deps =
-    pep8
-    pyflakes
+deps = flake8
 commands =
-    pyflakes inflect.py setup.py tests
-    pep8 --statistics --count .
+    flake8 .
 skip_install = true


### PR DESCRIPTION
I've added a configuration file so Travis CI will build each commit and pull request. It runs against each Python version supported by Travis CI: 2.6, 2.7, 3.2, 3.3, 3.4, PyPy and PyPy3, and all of them pass with no changes needed. This will help maintain the codebase by automatically running the tests against all Python versions for each PR -- it's very handy for picking up those Py2/Py3 inconsistencies.. 

It also runs the tests with coverage enabled, and sends the coverage reports to Coveralls, so you can see how coverage changes, or if a PR doesn't include tests to cover its new code. Right now, inflect.py has an amazing 98% coverage!

You get reports like this:

 * https://travis-ci.org/hugovk/inflect.py
 * https://coveralls.io/r/hugovk/inflect.py

I've added badges to the README to show off how good stats this project has. Both Travis CI and Coveralls are free for open source project, you just need to enable them for the repo. Please can you do so at:

 * https://travis-ci.org/profile
 * https://coveralls.io/repos/new

Thanks!