### PR TITLE
Use io module for simplicity and closer alignment to recommended usage.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 from distutils.core import setup
 import os
+import io
 
 import inflect
 
 
 here = os.path.dirname(__file__)
 readme_path = os.path.join(here, 'README.rst')
-readme = open(readme_path, 'rb').read().decode('utf-8')
+readme = io.open(readme_path, encoding='utf-8').read()
 
 setup(
     name='inflect',


### PR DESCRIPTION
In reviewing the code for #21, I found the issue was already fixed. I've struggled in the past with encoding issues on readme, and I've come to two solutions I prefer. If restricted to Python 2.6+, I use the io module. If supporting earlier Pythons, I use the codecs module.

I submit this request for your consideration, but feel free to reject it as it's only a stylistic preference; the existing commit is adequate to solve the issue.