### PR TITLE
Add fix for singular version of Status, Hiatus, etc

### DIFF
--- a/inflect.py
+++ b/inflect.py
@@ -2306,6 +2306,9 @@ class engine:
         if (self.classical_dict['herd'] and lowerword in pl_sb_uninflected_herd):
             return word
 
+        if lowerword in pl_sb_C_us_us:
+            return word
+
 # HANDLE COMPOUNDS ("Governor General", "mother-in-law", "aide-de-camp", ETC.)
 
         mo = search(r"^(?:%s)$" % pl_sb_postfix_adj_stems, word, IGNORECASE)

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -298,6 +298,9 @@ class test(unittest.TestCase):
         for sing, plur in (
             ('cat', 'cats'),
             ('die', 'dice'),
+            ('status', 'status'),
+            ('hiatus', 'hiatus'),
+            ('goose', 'geese'),
         ):
             self.assertEqual(p.singular_noun(plur), sing)
             self.assertEqual(p.inflect('singular_noun(%s)' % plur), sing)


### PR DESCRIPTION
It already works going the other way (`p.plural()`)